### PR TITLE
Removed company that has stated support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@
 - GreenAddress - Bitcoin web wallet
 - Slush Pool - Bitcoin mining pool
 - Samourai Wallet - Android Bitcoin wallet
-- breadwallet - most popular iOS Bitcoin wallet
 - Mycelium - popular Android Bitcoin wallet
 - [Ciphrex](https://twitter.com/ciphrex/status/895161633005346817) - Wallet
 - [Bitstop](https://twitter.com/bitstopofficial/status/895317733679669250) - Bitcoin ATM operator


### PR DESCRIPTION
Breadwallet supports the segwit2X chain, assuming it has majority hashpower.

Proof:  https://www.reddit.com/r/Bitcoin/comments/6sii2c/70_bitcoin_companies_exchange_and_wallets_that/dld38x3/