### PR TITLE
Removed coins.co.th  They are an original NYA agreement signer

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@
 - Bitt - Caribbean Bitcoin exchange
 - bitcoin.co.id - Indonesia's largest Bitcoin exchange
 - Coincheck - one of Japan's largest Bitcoin exchanges
-- coins.co.th - one of Thailand's largest Bitcoin brokers/exchange
 - bitcoin.co.th - one of Thailand's largest Bitcoin brokers/exchange
 - MaiCoin - Taiwanese Bitcoin exchange
 - [Bitonic](https://bitonic.nl/en/news/138/our-position-on-scaling-proposals) - Dutch Bitcoin broker


### PR DESCRIPTION
Coins.co.th is owned by the same people as Coin.ph

Coins.ph was an original new york agreement signer.

Here is a support ticket from them saying that they are the same, and that they support segwit2X.

https://imgur.com/a/fCofx

Here is the NYA saying that coins.ph supports segwit2X
https://medium.com/@DCGco/bitcoin-scaling-agreement-at-consensus-2017-133521fe9a77