### PR TITLE
Bittrex has not made any statements for or against

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@
 - Bitstamp - One of the world's largest Bitcoin exchanges
 - [Bitstop](https://twitter.com/bitstopofficial/status/895317733679669250) - Bitcoin ATM operator
 - Bitt - Caribbean Bitcoin exchange
-- Bittrex - World's second largest cryptocurrency exchange
 - Bity - Large European Bitcoin exchange
 - [Blockstream](http://blockstream.com) - Blockchain technologies provider
 - BuyaBitcoin - Australian cash to bitcoin exchange


### PR DESCRIPTION
Taking a similar stance to KeepKey in #10

Bittrex has not made a statement for or against Segwit2X. It has always been the stance of Bittrex remain neutral in discussions like this.

Bittrex did not sign the NYA. This does not imply we are for or against Segwit2X.
