### PR TITLE
add meetup groups and other organizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 
 ![](DG4IEcsUIAAje5w.jpg)
 
-### List of companies that did not sign or dropped from the NYA *(aka B2X or SegWit2x)*
+## List of companies and organizations that did not sign or dropped from the NYA *(aka B2X or SegWit2x)*
 
 - **[Add your name too ➕](https://github.com/nob2x/NOB2X/edit/master/README.md)**
+
+### Companies
+
 - [99Bitcoins](https://99bitcoins.com) - Bitcoin blog and information site
 - [2Bitcoins](https://2bitcoins.ru) - Russian Bitcoin news and mining portal
 - [Acinq](https://acinq.co) - Bitcoin LN scalability provider
@@ -124,6 +127,13 @@
 - [Xotika.tv](https://twitter.com/bitcoinerrorlog/status/895335674471043073) - Bitcoin Social Video-Streaming Platform
 - Zebpay - One of India's largest Bitcoin exchanges
 - GreenlawnGs - First non tech company to accept bitcoin in N Ireland
+
+### Meetup groups and other organizations:
+
+- [Bitcoin Munich Meetup](https://twitter.com/bitcoinerrorlog/status/895335674471043073)
+- [laBITconf](https://twitter.com/bitcoinerrorlog/status/895335674471043073)
+- [Seoul Bitcoin Meetup](https://twitter.com/bitcoinerrorlog/status/895335674471043073)
+
 ### Need clarification:
 
 - Huobi - Chinese Bitcoin exchange

--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@
 
 ### Meetup groups and other organizations:
 
-- [Bitcoin Munich Meetup](https://twitter.com/bitcoinerrorlog/status/895335674471043073)
-- [laBITconf](https://twitter.com/bitcoinerrorlog/status/895335674471043073)
-- [Seoul Bitcoin Meetup](https://twitter.com/bitcoinerrorlog/status/895335674471043073)
+- [Bitcoin Munich Meetup](https://i.imgur.com/WDK6Zed.jpg)
+- [laBITconf](https://twitter.com/laBITconf/status/918961053186318336)
+- [Seoul Bitcoin Meetup](https://medium.com/@seoulbitcoin/statement-on-segwit2x-161db1ad1976#---0-201)
 
 ### Need clarification:
 


### PR DESCRIPTION
I think it could be great to add meetup groups, as well as non-profits and other organizations. They're not companies but they're part of the ecosystem too, and many have an even greater interest in preserving Bitcoin's decentralisation and privacy than companies. A few of these have recently condemned B2X fork, and we should expect more will soon.

I also increased the weight of the title of the first first-level paragraph, so that it has the same weight as that of first-level paragraphs below.